### PR TITLE
Add configurable effect intervals

### DIFF
--- a/addons/sourcemod/scripting/chaos.sp
+++ b/addons/sourcemod/scripting/chaos.sp
@@ -254,17 +254,18 @@ public void OnGameFrame()
 				{
 					VScriptExecute hExecute = new VScriptExecute(HSCRIPT_RootTable.GetValue("Chaos_UpdateEffect"));
 					hExecute.SetParamString(1, FIELD_CSTRING, effect.script_file);
-					hExecute.Execute();
-					
-					float flUpdateInterval;
-					if (hExecute.ReturnType == FIELD_VOID)
-						flUpdateInterval = flDefaultUpdateInterval;
-					else
-						flUpdateInterval = float(hExecute.ReturnValue);
-					
-					delete hExecute;
-					
-					g_hEffects.Set(i, GetGameTime() + flUpdateInterval, ChaosEffect::next_script_update_time);
+					if (hExecute.Execute() != SCRIPT_ERROR)
+					{
+						float flUpdateInterval;
+						if (hExecute.ReturnType == FIELD_VOID)
+							flUpdateInterval = flDefaultUpdateInterval;
+						else
+							flUpdateInterval = float(hExecute.ReturnValue);
+						
+						delete hExecute;
+						
+						g_hEffects.Set(i, GetGameTime() + flUpdateInterval, ChaosEffect::next_script_update_time);
+					}
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/chaos.sp
+++ b/addons/sourcemod/scripting/chaos.sp
@@ -92,7 +92,7 @@ public Plugin myinfo =
 	name = "[TF2] Chaos Mod",
 	author = "Mikusch",
 	description = "Chaos Mod for Team Fortress 2, heavily inspired by Chaos Mod V.",
-	version = "1.4.0",
+	version = "1.5.0",
 	url = "https://github.com/Mikusch/ChaosModTF2"
 }
 

--- a/addons/sourcemod/scripting/chaos/data.sp
+++ b/addons/sourcemod/scripting/chaos/data.sp
@@ -25,6 +25,8 @@ enum struct ChaosEffect
 	float activate_time;
 	int cooldown_left;
 	float current_duration;
+	float next_update_time;
+	float next_script_update_time;
 	
 	void Parse(KeyValues kv)
 	{

--- a/scripts/vscripts/chaos.nut
+++ b/scripts/vscripts/chaos.nut
@@ -70,9 +70,11 @@ function Chaos_UpdateEffect(name)
 	local scope = ChaosEffectScopes[scopeName]
 	if (scope == null)
 		return
-	
-	if ("ChaosEffect_Update" in scope)
-		return scope.ChaosEffect_Update()
+
+	if (!("ChaosEffect_Update" in scope))
+		return
+
+	return scope.ChaosEffect_Update()
 }
 
 function Chaos_EndEffect(name)

--- a/scripts/vscripts/chaos.nut
+++ b/scripts/vscripts/chaos.nut
@@ -61,13 +61,18 @@ function Chaos_StartEffect(name, duration)
 	return success
 }
 
-function Chaos_UpdateEffects()
+function Chaos_UpdateEffect(name)
 {
-	foreach (scopeName, scope in ChaosEffectScopes)
-	{
-		if ("ChaosEffect_Update" in scope)
-			scope.ChaosEffect_Update()
-	}
+	local scopeName = CHAOS_NAMESPACE + name
+	if (!(scopeName in ChaosEffectScopes))
+		return
+
+	local scope = ChaosEffectScopes[scopeName]
+	if (scope == null)
+		return
+	
+	if ("ChaosEffect_Update" in scope)
+		return scope.ChaosEffect_Update()
 }
 
 function Chaos_EndEffect(name)

--- a/scripts/vscripts/chaos/effects/bouncyrockets.nut
+++ b/scripts/vscripts/chaos/effects/bouncyrockets.nut
@@ -1,38 +1,29 @@
+// Contributed by Dencube
+
 function ChaosEffect_Update()
 {
-    local rocket = null
-    while (rocket = Entities.FindByClassname(rocket, "tf_projectile_rocket"))
-    {
-        ProcessRocket(rocket)
-    }
+	local projectile
+	while (projectile = Entities.FindByClassname(projectile, "tf_projectile_*"))
+	{
+		local velocity = projectile.GetAbsVelocity()
+		local direction = velocity
+		local speed = direction.Norm()
 
-    local rocket = null
-    while (rocket = Entities.FindByClassname(rocket, "tf_projectile_energy_ball"))
-    {
-        ProcessRocket(rocket)
-    }
-}
+		local trace =
+		{
+			start = projectile.GetOrigin(),
+			end = projectile.GetOrigin() + (direction * 12.0),
+			mask = (Constants.FContents.CONTENTS_SOLID | Constants.FContents.CONTENTS_WINDOW | Constants.FContents.CONTENTS_GRATE | Constants.FContents.CONTENTS_MOVEABLE),
+			ignore = projectile
+		}
 
-function ProcessRocket(rocket)
-{
-    local velocity = rocket.GetAbsVelocity()
-    local direction = velocity
-    local speed = direction.Norm()
+		if (TraceLineEx(trace) && trace.hit)
+		{
+			local new_direction = direction - (trace.plane_normal * direction.Dot(trace.plane_normal) * 2.0)
+			projectile.SetAbsVelocity(new_direction * speed)
+			projectile.SetForwardVector(new_direction)
+		}
+	}
 
-    local trace =
-    {
-        start = rocket.GetOrigin(),
-        end = rocket.GetOrigin() + (direction * 12.0),
-        mask = (Constants.FContents.CONTENTS_SOLID | Constants.FContents.CONTENTS_WINDOW | Constants.FContents.CONTENTS_GRATE | Constants.FContents.CONTENTS_MOVEABLE),
-        ignore = rocket
-    }
-
-    TraceLineEx(trace)
-
-    if (trace.hit)
-    {
-        local new_direction = direction - (trace.plane_normal * direction.Dot(trace.plane_normal) * 2.0)
-        rocket.SetAbsVelocity(new_direction * speed)
-        rocket.SetForwardVector(new_direction)
-    }
+	return -1
 }

--- a/scripts/vscripts/chaos/effects/homingprojectiles.nut
+++ b/scripts/vscripts/chaos/effects/homingprojectiles.nut
@@ -27,6 +27,8 @@ function ChaosEffect_Update()
 
 		AttachProjectileThinker(projectile)
 	}
+
+	return -1
 }
 
 function ChaosEffect_OnEnd()

--- a/scripts/vscripts/chaos/effects/homingprojectiles.nut
+++ b/scripts/vscripts/chaos/effects/homingprojectiles.nut
@@ -144,7 +144,8 @@ function Chaos_OnScriptHook_OnTakeDamage(params)
 	if (params.const_entity == worldspawn)
 		return
 
-	if (params.inflictor.GetClassname() != "tf_projectile_energy_ring")
+	local classname = params.inflictor.GetClassname()
+	if (classname != "tf_projectile_flare" && classname != "tf_projectile_energy_ring")
 		return
 
 	EntFireByHandle(params.inflictor, "Kill", null, 0.5, null, null)

--- a/scripts/vscripts/chaos/effects/homingprojectiles.nut
+++ b/scripts/vscripts/chaos/effects/homingprojectiles.nut
@@ -1,11 +1,13 @@
+// Contributed by Kamuixmod
+
 const TURN_RATE = 0.75
 
 local validProjectiles =
 {
 	tf_projectile_arrow				= 0
-	tf_projectile_energy_ball		= 0 // Cow mangler
+	tf_projectile_energy_ball		= 0 // Cow Mangler
 	tf_projectile_healing_bolt		= 0 // Crusader's Crossbow, Rescue Ranger
-	tf_projectile_lightningorb		= 0 // Spell Variant from Short Circuit
+	tf_projectile_lightningorb		= 0 // Lightning Orb Spell
 	tf_projectile_mechanicalarmorb	= 0 // Short Circuit
 	tf_projectile_rocket			= 0
 	tf_projectile_sentryrocket		= 0
@@ -44,7 +46,7 @@ function ChaosEffect_OnEnd()
 {
 	local new_target = SelectVictim(self)
 	if (new_target != null && IsLookingAt(self, new_target))
-		FaceToward(new_target, self, projectile_speed)
+		FaceTowards(new_target, self, projectile_speed)
 
 	return -1
 }
@@ -121,7 +123,7 @@ function ChaosEffect_OnEnd()
 	return true
 }
 
-::FaceToward <- function(new_target, projectile, projectile_speed)
+::FaceTowards <- function(new_target, projectile, projectile_speed)
 {
 	local desired_dir = new_target.EyePosition() - projectile.GetOrigin()
 		desired_dir.Norm()

--- a/scripts/vscripts/chaos/effects/uncontrollablerecoil.nut
+++ b/scripts/vscripts/chaos/effects/uncontrollablerecoil.nut
@@ -42,6 +42,8 @@ function ChaosEffect_Update()
 			player.ViewPunch(QAngle(-1, RandomInt(-1.5, 1.5), 0))
 		}
 	}
+
+	return -1
 }
 
 function Chaos_OnGameEvent_player_spawn(params)


### PR DESCRIPTION
Effects can now define the rate at which they update. This both adds more control and heavily reduces CPU usage by not having to update several effects every frame.

The default value is defined in `sm_chaos_effect_update_interval` (def: `0.1`).
The update interval can be defined in the return value of the update function:

```squirrel
function ChaosEffect_Update()
{
	// Update in `sm_chaos_effect_update_interval` seconds
	if (someCondition)
		return null
	
	// Update in 0.5 seconds
	if (someOtherCondition)
		return 0.5

	// Update next frame
	return -1
}
```

* SourcePawn effects that return `void` or a `float` value of `0.0` will use the default value
* VScript effects that return `null` will use the default value

To guarantee execution on the next frame for any effect type, return `-1`.