### PR TITLE
Fix RemoveHealthAndAmmo ammo search loop

### DIFF
--- a/addons/sourcemod/scripting/chaos/effects/removehealthandammo.sp
+++ b/addons/sourcemod/scripting/chaos/effects/removehealthandammo.sp
@@ -13,7 +13,7 @@ public bool RemoveHealthAndAmmo_OnStart(ChaosEffect effect)
 	}
 	
 	int ammopack = -1;
-	while ((healthkit = FindEntityByClassname(ammopack, "item_ammopack_*")) != -1)
+	while ((ammopack = FindEntityByClassname(ammopack, "item_ammopack_*")) != -1)
 	{
 		RemoveEntity(ammopack);
 		bRemovedAmmo = true;


### PR DESCRIPTION
## Summary
- fix incorrect variable use when removing ammo packs
- use tabs for indentation

## Testing
- `apt-get update`
- `apt-get install -y vim-common`


------
https://chatgpt.com/codex/tasks/task_e_68413ec1a30c8333b85115585cb05c53